### PR TITLE
Change exec move to msbuild native copy

### DIFF
--- a/AskToPortal/AskToPortal.csproj
+++ b/AskToPortal/AskToPortal.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <AssemblyName>AskToPortal</AssemblyName>
     <RootNamespace>AskToPortal</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -38,7 +35,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="move &quot;bin\Release\net472\AskToPortal.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+    <Copy SourceFiles="$(OutDir)AskToPortal.dll" DestinationFolder="$(VRChatPath)Mods" />
   </Target>
   
 </Project>

--- a/AvatarHider/AvatarHider.csproj
+++ b/AvatarHider/AvatarHider.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\AvatarHider.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)AvatarHider.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/ChairExitController/ChairExitController.csproj
+++ b/ChairExitController/ChairExitController.csproj
@@ -14,7 +14,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\ChairExitController.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)ChairExitController.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/CloningBeGone/CloningBeGone.csproj
+++ b/CloningBeGone/CloningBeGone.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\CloningBeGone.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)CloningBeGone.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 	
 </Project>

--- a/InstanceHistory/InstanceHistory.csproj
+++ b/InstanceHistory/InstanceHistory.csproj
@@ -34,7 +34,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\InstanceHistory.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)InstanceHistory.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/PlayerList/PlayerList.csproj
+++ b/PlayerList/PlayerList.csproj
@@ -66,7 +66,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\PlayerList.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)PlayerList.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/PreviewScroller/PreviewScroller.csproj
+++ b/PreviewScroller/PreviewScroller.csproj
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\PreviewScroller.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)PreviewScroller.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/PrivateInstanceIcon/PrivateInstanceIcon.csproj
+++ b/PrivateInstanceIcon/PrivateInstanceIcon.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 	
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\PrivateInstanceIcon.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)PrivateInstanceIcon.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/ReloadAvatars/ReloadAvatars.csproj
+++ b/ReloadAvatars/ReloadAvatars.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 	
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="move &quot;bin\Release\net472\ReloadAvatars.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+	  <Copy SourceFiles="$(OutDir)ReloadAvatars.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/RememberMe/RememberMe.csproj
+++ b/RememberMe/RememberMe.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\RememberMe.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)RememberMe.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/SelectYourself/SelectYourself.csproj
+++ b/SelectYourself/SelectYourself.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\SelectYourself.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)SelectYourself.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/TriggerESP/TriggerESP.csproj
+++ b/TriggerESP/TriggerESP.csproj
@@ -51,7 +51,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\TriggerESP.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)TriggerESP.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/UserHistory/UserHistory.csproj
+++ b/UserHistory/UserHistory.csproj
@@ -21,7 +21,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\UserHistory.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)UserHistory.dll" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 </Project>

--- a/UserInfoExtensions/UserInfoExtensions.csproj
+++ b/UserInfoExtensions/UserInfoExtensions.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <AssemblyName>UserInfoExtensions</AssemblyName>
     <RootNamespace>UserInfoExtensions</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -37,7 +34,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="move &quot;bin\Release\net472\UserInfoExtensions.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
+	  <Copy SourceFiles="$(OutDir)UserInfoExtensions.dll" DestinationFolder="$(VRChatPath)Mods" />
   </Target>
 
 </Project>

--- a/VRChatUtilityKit/VRChatUtilityKit.csproj
+++ b/VRChatUtilityKit/VRChatUtilityKit.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="move &quot;bin\Release\net472\VRChatUtilityKit.dll&quot; &quot;$(VRChatPath)Mods&quot;" />
-		<Exec Command="move &quot;bin\Release\net472\VRChatUtilityKit.xml&quot; &quot;$(VRChatPath)Mods&quot;" />
+		<Copy SourceFiles="$(OutDir)VRChatUtilityKit.dll" DestinationFolder="$(VRChatPath)Mods" />
+		<Copy SourceFiles="$(ProjectDir)VRChatUtilityKit.xml" DestinationFolder="$(VRChatPath)Mods" />
 	</Target>
 
 	<ItemGroup>


### PR DESCRIPTION
Fixes some of the last issues for compiling on linux, by changing arbitrary exec commands to move the DLL's to msbuild native copy, and use macros to copy the Debug or Release build dll, depending on the build type instead of always only moving the Release build.
Also moved a few `AllowUnsafeBlocks` properties from conditional to non-conditional `PropertyGroup`s to allow compiling Debug builds of them too.